### PR TITLE
More GKE examples

### DIFF
--- a/INDEX.md
+++ b/INDEX.md
@@ -11,7 +11,7 @@
 | `for`                      | [aws, aws_vpc](aws/aws_vpc/for) |
 | `for_each`                 | [map, local](local/null_resource/for_each) <p/> [aws](aws/aws_instance/for_each) |
 | `google_compute_network`   | [google](google/google_compute_network/simple) |
-| `google_container_cluster` | [google, GKE](google/google_container_cluster/simple) <p/> [separate-node-pool](google/google_container_cluster/separate-node-pool) |
+| `google_container_cluster` | [google, GKE](google/google_container_cluster/simple) <p/> [separate-node-pool](google/google_container_cluster/separate-node-pool) <p/> [cluster-and-deployment](google/google_container_cluster/cluster-and-deployment) |
 | `helm_release`             | [simple](helm/helm_release/simple) <p/> [values_from_file](helm/helm_release/values_from_file) |
 | `inline`                   | [aws, remote-exec](aws/aws_instance/remote-exec/inline/) |
 | `kubernetes_config_map`    | [simple](kubernetes/kubernetes_config_map/simple) <p/> [data_from_files](kubernetes/kubernetes_config_map/from_files) |

--- a/INDEX.md
+++ b/INDEX.md
@@ -11,7 +11,7 @@
 | `for`                      | [aws, aws_vpc](aws/aws_vpc/for) |
 | `for_each`                 | [map, local](local/null_resource/for_each) <p/> [aws](aws/aws_instance/for_each) |
 | `google_compute_network`   | [google](google/google_compute_network/simple) |
-| `google_container_cluster` | [google, GKE](google/google_container_cluster/simple) <p/> [separate-node-pool](google/google_container_cluster/separate-node-pool) <p/> [cluster-and-deployment](google/google_container_cluster/cluster-and-deployment) |
+| `google_container_cluster` | [google, GKE](google/google_container_cluster/simple) <p/> [separate-node-pool](google/google_container_cluster/separate-node-pool) <p/> [cluster-and-deployment](google/google_container_cluster/cluster-and-deployment) <p/> [vpc_native_cluster](google/google_container_cluster/vpc_native_cluster) |
 | `helm_release`             | [simple](helm/helm_release/simple) <p/> [values_from_file](helm/helm_release/values_from_file) |
 | `inline`                   | [aws, remote-exec](aws/aws_instance/remote-exec/inline/) |
 | `kubernetes`               | [kubernetes](kubernetes) |

--- a/aws/aws_instance/remote-exec/inline/main.tf
+++ b/aws/aws_instance/remote-exec/inline/main.tf
@@ -77,7 +77,7 @@ resource "aws_security_group_rule" "changeme_incoming_ssh" {
 # Documentation: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance
 resource "aws_instance" "changeme_aws_instance" {
   # Documentation: https://www.terraform.io/docs/language/meta-arguments/count.html
-  count                  = 2
+  count = 2
 
   instance_type          = "t2.nano"
   ami                    = "ami-0ddbdea833a8d2f0d"

--- a/bin/check_format.sh
+++ b/bin/check_format.sh
@@ -5,10 +5,13 @@ set -o nounset
 
 cd "${0%/*}/.."
 
-if [[ $(terraform fmt -recursive -diff > fmt.out 2>&1) != '' ]]
+terraform fmt -recursive -diff > fmt.out 2>&1
+if [[ -s fmt.out ]]
 then
   echo "Terraform fmt failed"
   cat fmt.out
   rm fmt.out
   exit 1
+else
+  rm fmt.out
 fi

--- a/google/google_compute_network/simple/main.tf
+++ b/google/google_compute_network/simple/main.tf
@@ -13,7 +13,7 @@ terraform {
 
 # Documentation: https://www.terraform.io/docs/language/values/variables.html
 variable "project_id" {
-  type        = string
+  type = string
 }
 
 # Documentation: https://www.terraform.io/docs/language/providers/requirements.html

--- a/google/google_container_cluster/cluster-and-deployment/destroy.sh
+++ b/google/google_container_cluster/cluster-and-deployment/destroy.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+../../../bin/destroy_google.sh

--- a/google/google_container_cluster/cluster-and-deployment/main.tf
+++ b/google/google_container_cluster/cluster-and-deployment/main.tf
@@ -1,5 +1,6 @@
 # Summary: Creates a GKE (Google Kubernetes Engine) cluster, connects the Terraform Kubernetes Provider to it, and creates a k8s deployment.
 
+# Documentation: https://www.terraform.io/docs/language/settings/index.html
 terraform {
   required_version = ">= 0.14.0"
   required_providers {
@@ -10,10 +11,12 @@ terraform {
   }
 }
 
+# Documentation: https://www.terraform.io/docs/language/values/variables.html
 variable "project_id" {
   type = string
 }
 
+# Documentation: https://www.terraform.io/docs/language/providers/requirements.html
 provider "google" {
   project = var.project_id
   region  = "us-central1"
@@ -22,7 +25,7 @@ provider "google" {
 
 # GKE
 # Documentation: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster
-resource "google_container_cluster" "changeme-cluster-and-deployment-cluster" {
+resource "google_container_cluster" "changeme_cluster_and_deployment_cluster" {
   name               = "changeme-cluster-and-deployment-cluster"
   location           = "us-central1-a"
   initial_node_count = 1
@@ -40,16 +43,16 @@ data "google_client_config" "provider" {}
 
 # Documentation: https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs
 provider "kubernetes" {
-  host  = "https://${google_container_cluster.changeme-cluster-and-deployment-cluster.endpoint}"
+  host  = "https://${google_container_cluster.changeme_cluster_and_deployment_cluster.endpoint}"
   token = data.google_client_config.provider.access_token
   cluster_ca_certificate = base64decode(
-    google_container_cluster.changeme-cluster-and-deployment-cluster.master_auth[0].cluster_ca_certificate,
+    google_container_cluster.changeme_cluster_and_deployment_cluster.master_auth[0].cluster_ca_certificate,
   )
 }
 
 # Deployment
 # Documentation: https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/deployment
-resource "kubernetes_deployment" "changeme-cluster-and-deployment-deployment" {
+resource "kubernetes_deployment" "changeme_cluster_and_deployment_deployment" {
   metadata {
     name = "changeme-cluster-and-deployment-deployment"
     labels = {

--- a/google/google_container_cluster/cluster-and-deployment/main.tf
+++ b/google/google_container_cluster/cluster-and-deployment/main.tf
@@ -1,4 +1,4 @@
-# Summary: Creates a GKE (Google Kubernetes Engine) cluster, connects the Terraform Kubernetes Provider to it, and creates a k8s deplyment.
+# Summary: Creates a GKE (Google Kubernetes Engine) cluster, connects the Terraform Kubernetes Provider to it, and creates a k8s deployment.
 
 terraform {
   required_version = ">= 0.14.0"

--- a/google/google_container_cluster/cluster-and-deployment/main.tf
+++ b/google/google_container_cluster/cluster-and-deployment/main.tf
@@ -1,0 +1,81 @@
+# Summary: Creates a GKE (Google Kubernetes Engine) cluster, connects the Terraform Kubernetes Provider to it, and creates a k8s deplyment.
+
+terraform {
+  required_version = ">= 0.14.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 3.0"
+    }
+  }
+}
+
+variable "project_id" {
+  type = string
+}
+
+provider "google" {
+  project = var.project_id
+  region  = "us-central1"
+  zone    = "us-central1-a"
+}
+
+# GKE
+# Documentation: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster
+resource "google_container_cluster" "changeme-cluster-and-deployment-cluster" {
+  name               = "changeme-cluster-and-deployment-cluster"
+  location           = "us-central1-a"
+  initial_node_count = 1
+  node_config {
+    preemptible  = true
+    machine_type = "n1-standard-1"
+  }
+}
+
+# Kubernetes
+# Documentation: https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/using_gke_with_terraform
+
+# # Explanation: Retrieve an access token as the Terraform runner
+data "google_client_config" "provider" {}
+
+# Documentation: https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs
+provider "kubernetes" {
+  host  = "https://${google_container_cluster.changeme-cluster-and-deployment-cluster.endpoint}"
+  token = data.google_client_config.provider.access_token
+  cluster_ca_certificate = base64decode(
+    google_container_cluster.changeme-cluster-and-deployment-cluster.master_auth[0].cluster_ca_certificate,
+  )
+}
+
+# Deployment
+# Documentation: https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/deployment
+resource "kubernetes_deployment" "changeme-cluster-and-deployment-deployment" {
+  metadata {
+    name = "changeme-cluster-and-deployment-deployment"
+    labels = {
+      app = "changeme-cluster-and-deployment-app"
+    }
+  }
+
+  spec {
+    replicas = 1
+    selector {
+      match_labels = {
+        app = "changeme-cluster-and-deployment-app"
+      }
+    }
+    template {
+      metadata {
+        labels = {
+          app = "changeme-cluster-and-deployment-app"
+        }
+      }
+      spec {
+        container {
+          image = "nginx"
+          name  = "nginx"
+        }
+      }
+    }
+  }
+}

--- a/google/google_container_cluster/cluster-and-deployment/run.sh
+++ b/google/google_container_cluster/cluster-and-deployment/run.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+../../../bin/apply_google.sh

--- a/google/google_container_cluster/vpc_native_cluster/destroy.sh
+++ b/google/google_container_cluster/vpc_native_cluster/destroy.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+../../../bin/destroy_google.sh

--- a/google/google_container_cluster/vpc_native_cluster/main.tf
+++ b/google/google_container_cluster/vpc_native_cluster/main.tf
@@ -1,0 +1,71 @@
+# Summary: Creates a VPC-native GKE (Google Kubernetes Engine) cluster .
+# Documentation: https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/using_gke_with_terraform#vpc-native-clusters
+
+# Documentation: https://www.terraform.io/docs/language/settings/index.html
+terraform {
+  required_version = ">= 0.14.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 3.0"
+    }
+  }
+}
+
+# Documentation: https://www.terraform.io/docs/language/values/variables.html
+variable "project_id" {
+  type = string
+}
+
+# Documentation: https://www.terraform.io/docs/language/providers/requirements.html
+provider "google" {
+  project = var.project_id
+  region  = "us-central1"
+  zone    = "us-central1-a"
+}
+
+# Google VPC network
+# Documentation: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_network
+resource "google_compute_network" "changeme_vpc_native_cluster_network" {
+  name                    = "changeme-vpc-native-cluster-network"
+  auto_create_subnetworks = false
+}
+
+# Subnetwork
+# Documentation: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_subnetwork
+resource "google_compute_subnetwork" "changeme_vpc_native_cluster_subnetwork" {
+  name          = "changeme-vpc-native-cluster-subnetwork"
+  ip_cidr_range = "10.2.0.0/16"
+  region        = "us-central1"
+  network       = google_compute_network.changeme_vpc_native_cluster_network.id
+  secondary_ip_range {
+    range_name    = "services-range"
+    ip_cidr_range = "192.168.1.0/24"
+  }
+
+  secondary_ip_range {
+    range_name    = "pod-ranges"
+    ip_cidr_range = "192.168.64.0/22"
+  }
+}
+
+# GKE
+# Documentation: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster
+resource "google_container_cluster" "changeme_vpc_native_cluster" {
+  name               = "changeme-vpc-native-cluster"
+  location           = "us-central1-a"
+  initial_node_count = 1
+
+  network    = google_compute_network.changeme_vpc_native_cluster_network.id
+  subnetwork = google_compute_subnetwork.changeme_vpc_native_cluster_subnetwork.id
+
+  ip_allocation_policy {
+    cluster_secondary_range_name  = "services-range"
+    services_secondary_range_name = google_compute_subnetwork.changeme_vpc_native_cluster_subnetwork.secondary_ip_range.1.range_name
+  }
+
+  node_config {
+    preemptible  = true
+    machine_type = "n1-standard-1"
+  }
+}

--- a/google/google_container_cluster/vpc_native_cluster/run.sh
+++ b/google/google_container_cluster/vpc_native_cluster/run.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+../../../bin/apply_google.sh


### PR DESCRIPTION
It is still work in progress.

1. [x] cluster-and-deployment – creates a GKE cluster, connects the Terraform Kubernetes Provider to it, and creates a k8s deployment.
2. [x] VPC-native cluster