### PR TITLE
Corrected some examples (use dashes in `name =`)

### DIFF
--- a/google/google_compute_network/simple/main.tf
+++ b/google/google_compute_network/simple/main.tf
@@ -12,14 +12,13 @@ terraform {
 }
 
 # Documentation: https://www.terraform.io/docs/language/values/variables.html
-variable "changeme_project_id" {
-  description = "project id"
+variable "project_id" {
   type        = string
 }
 
 # Documentation: https://www.terraform.io/docs/language/providers/requirements.html
 provider "google" {
-  project = var.changeme_project_id
+  project = var.project_id
   region  = "us-central1"
   zone    = "us-central1-c"
 }
@@ -32,7 +31,7 @@ resource "google_compute_network" "changeme_vpc_simple" {
 
 # Documentation: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_subnetwork
 resource "google_compute_subnetwork" "changeme_vpc_simple_subnet_1" {
-  name          = "changeme_${google_compute_network.changeme_vpc_simple.name}_subnet_1"
+  name          = "changeme-${google_compute_network.changeme_vpc_simple.name}-subnet-1"
   region        = "us-central1"
   network       = google_compute_network.changeme_vpc_simple.name
   ip_cidr_range = "10.10.0.0/24"

--- a/helm/helm_release/values_from_file/main.tf
+++ b/helm/helm_release/values_from_file/main.tf
@@ -13,7 +13,7 @@ terraform {
 
 # Documentation: https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release
 resource "helm_release" "changeme_release_values_from_file_ingress_nginx" {
-  name = "changeme_release_values_from_file_ingress_nginx_name"
+  name = "changeme-release-values-from-file-ingress-nginx-name"
 
   repository = "https://kubernetes.github.io/ingress-nginx"
   chart      = "ingress-nginx"


### PR DESCRIPTION
- use dashes in cloud resource names (the name attribute)
- fix variable name: `project_id` to match what's defined in [bin/shared_google.sh](https://github.com/ContainerSolutions/terraform-examples/blob/main/bin/shared_google.sh)

Corrected examples:
- google/google_compute_network/simple
- helm/helm_release/values_from_file