### PR TITLE
Add analytics header

### DIFF
--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -1,0 +1,11 @@
+{% if jekyll.environment == 'production' %}
+<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-TKE13514P9"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-7K97J66TL4');
+</script>
+{% endif %}


### PR DESCRIPTION
Added Google analytics header. On the Google side I've set the site to https://containersolutions.github.io/terraform-examples/, so I guess that URL might need updated at some point.