### PR TITLE
Improve pull_request_template and add "inline documentation" conventions to README

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,16 @@
-Resolves issue #
+Link issues resolved by this:
+Resolves #
 
 Changes/added features:
 -
-- 
+-
 
 The following short checklist should be used to make sure your PR is of good quality, and can be merged easily:
 - [ ] follows [project conventions](https://github.com/ContainerSolutions/terraform-examples#conventions)
 - [ ] follows [project principles](https://github.com/ContainerSolutions/terraform-examples#principles)
+- [ ] `./run.sh` works correctly for all new examples
 - [ ] CI checks pass
-- [ ] mergeable to main
+- [ ] mergeable to main (no conflicts)
 - [ ] resolved issues linked
 
 Reviewers:

--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ The examples seek to be:
 - For help with automated testing
   - where possible, add some way to enable 'left-over' resources to be cleaned up, eg provider `default_tags` of `cs_terraform_examples` in AWS provider blocks
 
+- Add inline documentation for each Terraform code block
+  - `# Summary:` – 1-line summary of what this example does
+  - `# Documentation:` – add link to documentation before each block (terraform, provider, variable, resource, etc.)
+  - `# Explanation:` – add only where some extra explanation is needed
+
 ## GitHub Actions Workflow
 
 On every commit, the following tests run on all branches:


### PR DESCRIPTION
It's related to: #58 

Changes/added features:
- Add a successful `./run.sh` to PR checklist (in `.github/pull_request_template.md`)
- Add "inline documentation" conventions (to `README.md`)

The following short checklist should be used to make sure your PR is of good quality, and can be merged easily:
- [x] follows [project conventions](https://github.com/ContainerSolutions/terraform-examples#conventions)
- [x] follows [project principles](https://github.com/ContainerSolutions/terraform-examples#principles)
- [x] CI checks pass
- [x] mergeable to main
- [x] resolved issues linked

Reviewers:
@ianmiell
@ttarczynski
@sanyer
