### PR TITLE
Fixed bin/check_scripts.sh to display correct dir if a check has failed

### DIFF
--- a/bin/check_scripts.sh
+++ b/bin/check_scripts.sh
@@ -20,6 +20,7 @@ do
     if ! [ -x "${script}" ]
     then
       echo "$folder/$script should exist and be executable, but is/does not"
+      popd
       ls -l "${folder}"
       exit 1
     fi


### PR DESCRIPTION
Link related issues:
- Progress towards #52

Changes/added features:
- Fixes a small bug in `bin/check_scripts.sh`. When this check has failed it wasn't listing the correct directory. Plus the error messages were misleading.

Bug fixed:
- resolved a problem in `bin/check_scripts.sh` as could be seen in this GitHub actions run: https://github.com/ContainerSolutions/terraform-examples/runs/4808091030?check_suite_focus=true

I've tested it manually on local, and also in our CI:
* https://github.com/ContainerSolutions/terraform-examples/actions/runs/1695153885

The following short checklist should be used to make sure your PR is of good quality, and can be merged easily:
- [x] follows [project conventions](https://github.com/ContainerSolutions/terraform-examples#conventions)
- [x] follows [project principles](https://github.com/ContainerSolutions/terraform-examples#principles)
- [x] `./run.sh` works correctly for all new examples
- [x] CI checks pass
- [x] mergeable to main (no conflicts)
- [x] resolved issues linked
- [x] [Milestone](https://github.com/ContainerSolutions/terraform-examples/milestones) linked (if applicable)

Reviewers:
@ianmiell
@ttarczynski
@sanyer
@teszes
@choilmto
@rodrigorras
@vmhlotsh1