### PR TITLE
Adding destroy flag to terraform plan in destroy.sh

### DIFF
--- a/bin/destroy.sh
+++ b/bin/destroy.sh
@@ -25,7 +25,7 @@ source ./shared_terraform_cloud.sh
 cd - || exit 1
 
 terraform init
-terraform plan
+terraform plan -destroy
 
 # If this is non-interactive, then auto-approve...
 if [[ $- == *i* ]]


### PR DESCRIPTION
Link related issues:
- There aren't any issues related to this bug

Changes/added features:
- Destroy flag was added to terraform plan in `destroy.sh`

The following short checklist should be used to make sure your PR is of good quality, and can be merged easily:
- [ ] follows [project conventions](https://github.com/ContainerSolutions/terraform-examples#conventions)
- [ ] follows [project principles](https://github.com/ContainerSolutions/terraform-examples#principles)
- [ ] `./run.sh` works correctly for all new examples
- [ ] CI checks pass
- [ ] mergeable to main (no conflicts)
- [ ] resolved issues linked
- [ ] [Milestone](https://github.com/ContainerSolutions/terraform-examples/milestones) linked (if applicable)

Reviewers:
@ianmiell
@ttarczynski
@sanyer
@teszes
@choilmto
@rodrigorras
