### PR TITLE
Use TFLINT_LOG instead of --loglevel cli argument and using fixed tflint version

### DIFF
--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -28,7 +28,7 @@ jobs:
           tflint_version: ${{ env.tflint_version }} # Must be specified. See: https://github.com/terraform-linters/tflint/releases for latest versions
       - name: Run TFLint
         # info level there because of WARNs and ERRs seen occasionally only in GitHub actions logs
-        run: find ${{ github.workspace }} | grep tf$ | xargs -n1 dirname | xargs -IXXX -n1 /bin/sh -c 'set -o errexit; cd XXX; pwd; tflint --loglevel=info .; cd - >/dev/null'
+        run: find ${{ github.workspace }} | grep tf$ | xargs -n1 dirname | xargs -IXXX -n1 /bin/sh -c 'set -o errexit; cd XXX; pwd; TFLINT_LOG=info tflint .; cd - >/dev/null'
   TFValidate:
     runs-on: ubuntu-latest
     needs: [check_comments_test]

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup TFLint
         uses: terraform-linters/setup-tflint@v1
         with:
-          tflint_version: ${{ env.tflint_version }} # Must be specified. See: https://github.com/terraform-linters/tflint/releases for latest versions
+          tflint_version: v0.38.1 # ${{ env.tflint_version }} # Must be specified. See: https://github.com/terraform-linters/tflint/releases for latest versions
       - name: Run TFLint
         # info level there because of WARNs and ERRs seen occasionally only in GitHub actions logs
         run: find ${{ github.workspace }} | grep tf$ | xargs -n1 dirname | xargs -IXXX -n1 /bin/sh -c 'set -o errexit; cd XXX; pwd; TFLINT_LOG=info tflint .; cd - >/dev/null'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@
 #           tflint_version: ${{ env.tflint_version }} # Must be specified. See: https://github.com/terraform-linters/tflint/releases for latest versions
 #       - name: Run TFLint
 #         # info level there because of WARNs and ERRs seen occasionally only in GitHub actions logs
-#         run: find ${{ github.workspace }} | grep tf$ | xargs -n1 dirname | xargs -IXXX -n1 /bin/sh -c 'set -o errexit; cd XXX; pwd; tflint --loglevel=info .; cd - >/dev/null'
+#         run: find ${{ github.workspace }} | grep tf$ | xargs -n1 dirname | xargs -IXXX -n1 /bin/sh -c 'set -o errexit; cd XXX; pwd; TFLINT_LOG=info tflint .; cd - >/dev/null'
 #   TFValidate:
 #     runs-on: ubuntu-latest
 #     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@
 # on: [push, pull_request]
 # env:
 #   terraform_version: latest
-#   tflint_version: latest
+#   tflint_version: v0.38.1
 # jobs:
 #   TFLint:
 #     runs-on: ubuntu-latest

--- a/.github/workflows/validations-ci.yml
+++ b/.github/workflows/validations-ci.yml
@@ -2,7 +2,7 @@ name: Main Pull Request
 on: [push, pull_request]
 env:
   terraform_version: latest
-  tflint_version: latest
+  tflint_version: v0.38.1
 jobs:
   TFLint:
     runs-on: ubuntu-latest

--- a/.github/workflows/validations-ci.yml
+++ b/.github/workflows/validations-ci.yml
@@ -17,7 +17,7 @@ jobs:
           tflint_version: ${{ env.tflint_version }} # Must be specified. See: https://github.com/terraform-linters/tflint/releases for latest versions
       - name: Run TFLint
         # info level there because of WARNs and ERRs seen occasionally only in GitHub actions logs
-        run: find ${{ github.workspace }} | grep tf$ | xargs -n1 dirname | xargs -IXXX -n1 /bin/sh -c 'set -o errexit; cd XXX; pwd; tflint --loglevel=info .; cd - >/dev/null'
+        run: find ${{ github.workspace }} | grep tf$ | xargs -n1 dirname | xargs -IXXX -n1 /bin/sh -c 'set -o errexit; cd XXX; pwd; TFLINT_LOG=info tflint .; cd - >/dev/null'
   TFValidate:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Link related issues:
- Resolves # (if merging this resolves the issue)
- Progress towards #184 (if it's incremental progress)

Changes/added features:
- Using `TFLINT_LOG` environment variable with tflint instead of removed `--loglevel` cli argument (See related PR in tflint repo: https://github.com/terraform-linters/tflint/pull/1470)

Error log:
```
Failed to parse CLI options; `loglevel` option was removed in v0.40.0. Please set `TFLINT_LOG` environment variables instead
```


The following short checklist should be used to make sure your PR is of good quality, and can be merged easily:
- [x] follows [project conventions](https://github.com/ContainerSolutions/terraform-examples#conventions)
- [x] follows [project principles](https://github.com/ContainerSolutions/terraform-examples#principles)
- [x] `./run.sh` works correctly for all new examples
- [ ] CI checks pass
- [x] mergeable to main (no conflicts)
- [x] resolved issues linked
- [x] [Milestone](https://github.com/ContainerSolutions/terraform-examples/milestones) linked (if applicable)

Reviewers:
@ianmiell
@ttarczynski
@sanyer
@teszes
@choilmto
@rodrigorras
